### PR TITLE
KONAMIコマンドでマインスイーパーのレベルが変えられるように

### DIFF
--- a/src/app/(bg)/bomb/page.tsx
+++ b/src/app/(bg)/bomb/page.tsx
@@ -1,17 +1,53 @@
 'use client'
 import { css } from '../../../../styled-system/css'
 import { MineSweeper } from '@/components'
+import { useState, ComponentProps } from 'react'
+import useKonami from 'use-konami'
+
+type LevelPropsType = {
+  name: string
+} & ComponentProps<typeof MineSweeper>
+
+const LEVEL_PROPS: LevelPropsType[] = [
+  {
+    name: 'easy',
+    cols: 7,
+    rows: 7,
+    bombs: 5,
+  },
+  {
+    name: 'normal',
+    cols: 9,
+    rows: 9,
+    bombs: 10,
+  },
+  {
+    name: 'difficult',
+    cols: 12,
+    rows: 12,
+    bombs: 20,
+  },
+]
 
 export default function Home() {
-  const cols = 9
-  const rows = 9
-  const bombs = 10
+  const [level, setLevel] = useState<number>(0)
+
+  useKonami({
+    onUnlock: () => {
+      setLevel((prev) => (prev + 1) % 3)
+    },
+  })
   return (
     <main>
       <div className={boxStyle}>
         <h1 className={h1Style}>マインスイーパー</h1>
+        <h2 className={h2Style}>{LEVEL_PROPS[level].name}</h2>
         <div className={gameContainerStyle}>
-          <MineSweeper cols={cols} rows={rows} bombs={bombs} />
+          <MineSweeper
+            cols={LEVEL_PROPS[level].cols}
+            rows={LEVEL_PROPS[level].rows}
+            bombs={LEVEL_PROPS[level].bombs}
+          />
         </div>
       </div>
     </main>
@@ -31,7 +67,19 @@ const h1Style = css({
   fontSize: '2xl',
   fontWeight: 'bold',
   textAlign: 'center',
-  paddingBottom: '1rem',
+  paddingBottom: '0.25rem',
+})
+
+const h2Style = css({
+  fontSize: 'lg',
+  textAlign: 'center',
+  paddingBottom: '0.75rem',
+  _before: {
+    content: '"~ "',
+  },
+  _after: {
+    content: '" ~"',
+  },
 })
 
 const gameContainerStyle = css({

--- a/src/app/(bg)/page.tsx
+++ b/src/app/(bg)/page.tsx
@@ -53,14 +53,14 @@ export default function Home() {
       </div>
 
       <div>
-        <a href="/rsa" className={styles.card}>
+        <a href="rsa" className={styles.card}>
           <h2>
             RSA暗号を作ってみよう！<span>-&gt;</span>
           </h2>
         </a>
       </div>
       <div>
-        <a href="/bomb" className={styles.card}>
+        <a href="bomb" className={styles.card}>
           <h2>
             マインスイーパー<span>-&gt;</span>
           </h2>

--- a/src/components/mine-sweeper/get-init-blocks.ts
+++ b/src/components/mine-sweeper/get-init-blocks.ts
@@ -1,5 +1,5 @@
 import { ComponentProps } from 'react'
-import { Block, BlockContentProps } from './block'
+import { BlockContentProps } from './block'
 import { getRandoms } from '@/utils'
 import { MineSweeper } from './mine-sweeper'
 

--- a/src/components/mine-sweeper/mine-sweeper.tsx
+++ b/src/components/mine-sweeper/mine-sweeper.tsx
@@ -4,6 +4,7 @@ import { Smily } from './smily'
 import { ElectronicSign } from './electronic-sign'
 import { useState, ComponentProps, useEffect } from 'react'
 import { getInitBlocks } from './get-init-blocks'
+import { openBlocks } from './open-blocks'
 
 type Props = {
   cols: number
@@ -55,11 +56,10 @@ export const MineSweeper = ({ cols, rows, bombs }: Props) => {
     setBlocks(nextBlocks)
   }
 
-  const handleClick = (x: number, y: number) => {
+  const handleOpen = (x: number, y: number) => {
     const tmpBlocks = blocks
-    const block = tmpBlocks[y][x]
-    if (block.open) return
-    if (block.bomb) {
+    if (tmpBlocks[y][x].open) return
+    if (tmpBlocks[y][x].bomb) {
       setSmilyStatus('gameover')
       const overBlocks = tmpBlocks.map((row) =>
         row.map((b) => {
@@ -70,22 +70,15 @@ export const MineSweeper = ({ cols, rows, bombs }: Props) => {
       setBlocks(overBlocks)
       return
     }
+    const openedBlocks = openBlocks(tmpBlocks, y, x, rows - 1, cols - 1)
     // ちゃんとコピーしないと反映されない
     let openCount = 0
-    const nextBlocks: BlockContentProps[][] = []
-    tmpBlocks.forEach((r, ri) => {
-      const nextRow: BlockContentProps[] = []
-      r.forEach((b, bi) => {
-        const tmpB = b
-        if (ri === y && bi === x) {
-          tmpB.open = true
-          openCount++
-          if (tmpB.flag) setFlags((prev) => prev - 1)
-        }
-        nextRow.push(tmpB)
-      })
-      nextBlocks.push(nextRow)
-    })
+    const nextBlocks = openedBlocks.map((r) =>
+      r.map((b) => {
+        if (b.open) openCount++
+        return b
+      }),
+    )
     setBlocks(nextBlocks)
     if (openCount === cols * rows - bombs) {
       setSmilyStatus('clear')
@@ -109,7 +102,7 @@ export const MineSweeper = ({ cols, rows, bombs }: Props) => {
                     key={`block-${x}.${y}`}
                     x={x}
                     y={y}
-                    onClick={handleClick}
+                    onClick={handleOpen}
                     onContextMenu={handleFlag}
                     block={block}
                   />

--- a/src/components/mine-sweeper/open-blocks.ts
+++ b/src/components/mine-sweeper/open-blocks.ts
@@ -1,0 +1,48 @@
+import { BlockContentProps } from './block'
+
+export const openBlocks = (
+  blocks: BlockContentProps[][],
+  y: number,
+  x: number,
+  maxY: number,
+  maxX: number,
+): BlockContentProps[][] => {
+  let thisBlocks = blocks
+  thisBlocks[y][x].open = true
+  if (thisBlocks[y][x].aroundSum > 0) {
+    return thisBlocks
+  }
+  // 北
+  if (0 < y && !thisBlocks[y - 1][x].open) {
+    thisBlocks = openBlocks(thisBlocks, y - 1, x, maxY, maxX)
+  }
+  // 北東
+  if (0 < y && x < maxX && !thisBlocks[y - 1][x + 1].open) {
+    thisBlocks = openBlocks(thisBlocks, y - 1, x + 1, maxY, maxX)
+  }
+  // 東
+  if (x < maxX && !thisBlocks[y][x + 1].open) {
+    thisBlocks = openBlocks(thisBlocks, y, x + 1, maxY, maxX)
+  }
+  // 南東
+  if (y < maxY && x < maxX && !thisBlocks[y + 1][x + 1].open) {
+    thisBlocks = openBlocks(thisBlocks, y + 1, x + 1, maxY, maxX)
+  }
+  // 南
+  if (y < maxY && !thisBlocks[y + 1][x].open) {
+    thisBlocks = openBlocks(thisBlocks, y + 1, x, maxY, maxX)
+  }
+  // 南西
+  if (y < maxY && 0 < x && !thisBlocks[y + 1][x - 1].open) {
+    thisBlocks = openBlocks(thisBlocks, y + 1, x - 1, maxY, maxX)
+  }
+  // 西
+  if (0 < x && !thisBlocks[y][x - 1].open) {
+    thisBlocks = openBlocks(thisBlocks, y, x - 1, maxY, maxX)
+  }
+  // 西
+  if (0 < y && 0 < x && !thisBlocks[y - 1][x - 1].open) {
+    thisBlocks = openBlocks(thisBlocks, y - 1, x - 1, maxY, maxX)
+  }
+  return thisBlocks
+}


### PR DESCRIPTION
# 概要

- [x] linkのバグ修正
- [x] KONAMIコマンドでマインスイーパーのレベルを上げる
- [x] 右の電光掲示板を時間経過に
- [x] 左の電光掲示板を(残りの爆弾の数 - フラグの数)
- [x] 空いているますを叩くと一気に全部空くように

<img width="250" alt="スクリーンショット 2023-12-09 0 23 48" src="https://github.com/ayumu-1212/orochi-noreview-app/assets/50935536/76bc2bd9-8620-411c-8b9c-ce9cca1ac8a6"><img width="250" alt="スクリーンショット 2023-12-09 0 24 00" src="https://github.com/ayumu-1212/orochi-noreview-app/assets/50935536/f431305a-7cfd-4111-a6f3-c2a45cd232f7"><img width="250" alt="スクリーンショット 2023-12-09 0 24 09" src="https://github.com/ayumu-1212/orochi-noreview-app/assets/50935536/7d546fe9-974e-4db5-9807-bcdb1f96fef3">




# リンク
- Qiita ID: [your qiita ID]()
<!--（あれば）
- 記事: [タイトル]()
-->