### PR TITLE
ブロック崩しゲームにゲームオーバー判定を追加

### DIFF
--- a/src/app/(bg)/block/page.tsx
+++ b/src/app/(bg)/block/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [difficulty, setDifficulty] = useState('easy')
   const [extremeClicks, setExtremeClicks] = useState(0)
-  const [remainingBallCount, setRemainingBallCount] = useState(3);
+  const [remainingBallCount, setRemainingBallCount] = useState(3)
 
   const handleExtremeClick = () => {
     setExtremeClicks((prevClicks) => prevClicks + 1)

--- a/src/app/(bg)/block/page.tsx
+++ b/src/app/(bg)/block/page.tsx
@@ -20,6 +20,12 @@ export default function Home() {
   }
 
   useEffect(() => {
+    /**
+     * NOTE: StrictModeによる二重レンダリング検知用フラグ
+     * これがないと残りのボール数を減らす処理が2回実行されてしまって辛い
+     */
+    let ignore = false
+
     if (canvasRef.current) {
       const canvas = canvasRef.current
       const context = canvas.getContext('2d')
@@ -254,7 +260,9 @@ export default function Home() {
           }
           totalBricks = brickRowCount * brickColumnCount
 
-          setRemainingBallCount(prev => prev - 1)
+          if (!ignore) {
+            setRemainingBallCount(prev => prev - 1)
+          }
         }
 
         if (rightPressed) {
@@ -275,6 +283,7 @@ export default function Home() {
       update()
 
       return () => {
+        ignore = true
         document.removeEventListener('keydown', keyDownHandler)
         document.removeEventListener('keyup', keyUpHandler)
         document.removeEventListener('mousemove', mouseMoveHandler)

--- a/src/app/(bg)/block/page.tsx
+++ b/src/app/(bg)/block/page.tsx
@@ -164,6 +164,13 @@ export default function Home() {
         }
       }
 
+      // 残りのボール数を描画する関数
+      const drawRemainingBallCount = () => {
+        context.font = '16px Arial'
+        context.fillStyle = '#0095DD'
+        context.fillText('残ボール数: 3', 15, 30)
+      }
+
       // ブロックとボールの衝突検出
       const collisionDetection = () => {
         for (let c = 0; c < brickColumnCount; c++) {
@@ -196,6 +203,7 @@ export default function Home() {
         drawBall()
         drawPaddle()
         drawBricks()
+        drawRemainingBallCount()
         collisionDetection()
 
         ballX += ballSpeedX

--- a/src/app/(bg)/block/page.tsx
+++ b/src/app/(bg)/block/page.tsx
@@ -10,6 +10,7 @@ export default function Home() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [difficulty, setDifficulty] = useState('easy')
   const [extremeClicks, setExtremeClicks] = useState(0)
+  const [remainingBallCount, setRemainingBallCount] = useState(3);
 
   const handleExtremeClick = () => {
     setExtremeClicks((prevClicks) => prevClicks + 1)
@@ -168,7 +169,7 @@ export default function Home() {
       const drawRemainingBallCount = () => {
         context.font = '16px Arial'
         context.fillStyle = '#0095DD'
-        context.fillText('残ボール数: 3', 15, 30)
+        context.fillText(`残ボール数: ${remainingBallCount}`, 15, 30)
       }
 
       // ブロックとボールの衝突検出
@@ -252,6 +253,8 @@ export default function Home() {
             }
           }
           totalBricks = brickRowCount * brickColumnCount
+
+          setRemainingBallCount(prev => prev - 1)
         }
 
         if (rightPressed) {
@@ -277,7 +280,7 @@ export default function Home() {
         document.removeEventListener('mousemove', mouseMoveHandler)
       }
     }
-  }, [difficulty])
+  }, [difficulty, remainingBallCount])
 
   return (
     <main>

--- a/src/app/(bg)/block/page.tsx
+++ b/src/app/(bg)/block/page.tsx
@@ -261,7 +261,14 @@ export default function Home() {
           totalBricks = brickRowCount * brickColumnCount
 
           if (!ignore) {
-            setRemainingBallCount(prev => prev - 1)
+            const newCount = remainingBallCount - 1
+            setRemainingBallCount(newCount)
+
+            // 残りのボール数が0になったらゲームオーバーのアラートを出す
+            if (newCount === 0) {
+              alert('ゲームオーバー🐍')
+              window.location.reload()
+            }
           }
         }
 


### PR DESCRIPTION
# 概要

ブロック崩しゲームにて、ボール数の制限を取り入れます。
残りのボール数が0になったらゲームオーバーとなります。

[![Image from Gyazo](https://i.gyazo.com/69b610ecb46fe7cf494b00d5f9966689.gif)](https://gyazo.com/69b610ecb46fe7cf494b00d5f9966689)

# リンク
- Qiita ID: [what_a_pon](https://qiita.com/what_a_pon)
<!--（あれば）
- 記事: [タイトル]()
-->